### PR TITLE
Get code compiling

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,7 +22,7 @@ pub fn build(b: *std.build.Builder) void {
     exe.linkSystemLibrary("GL");
     exe.linkSystemLibrary("GLEW");
     exe.addIncludePath("dos");
-    // exe.addCSourceFile("dos/dos.h", &[_][]const u8{});
+    exe.addCSourceFile("dos/dos.c", &[_][]const u8{});
 
     exe.install();
 

--- a/dos/dos.h
+++ b/dos/dos.h
@@ -198,6 +198,8 @@ int mousey( void );
 int mouserelx( void );
 int mouserely( void );
 
+int dosmain( int argc, const char* argv[] );
+
 #endif /* dos_h */
 
 
@@ -2157,8 +2159,6 @@ struct user_thread_context_t {
 };
 
 
-int dosmain( int argc, char* argv[] );
-
 #ifndef __wasm__
 static
 #else
@@ -3692,7 +3692,7 @@ void bin2arr( char const* src, char const* dst, char const* name ) {
 
 //*** main ***
 
-int main( int argc, char** argv ) {
+int dosmain( int argc, const char* argv[] ) {
     (void) argc, (void) argv;
 
     //bin2arr( "framecol.gif", "crtframecol.h", "crtframecol" );

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,5 +7,20 @@ const screen_height: i32 = 200;
 
 pub fn main() !void {
     std.debug.print("Testing Zig Voxel Engine.\n", .{});
+
+    var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+    const gpa = general_purpose_allocator.allocator();
+    const args = try std.process.argsAlloc(gpa);
+    defer std.process.argsFree(gpa, args);
+
+    // Convert the argument slices into just pointers, like C expects
+    const arg_pointers = try gpa.alloc(?[*:0]const u8, args.len);
+    defer gpa.free(arg_pointers);
+    for (args) |arg, index| {
+        arg_pointers[index] = arg.ptr;
+    }
+
+    _ = doslike.dosmain(@intCast(c_int, args.len), arg_pointers.ptr);
+
     doslike.setvideomode(doslike.videomode_320x200);
 }


### PR DESCRIPTION
I finished renaming the `main` function to `dosmain`, and also moved the forward declaration of `dosmain` up so it would be included without defining `DOS_IMPLEMENTATION`.

The signature was tweaked to make `argv` accept a list of `[*]const u8` strings.

This also adds in the allocator setup code and creating a c-compatible list of arguments on the Zig side.